### PR TITLE
Removing gsoc-2017 Announcement

### DIFF
--- a/static/md/home.md
+++ b/static/md/home.md
@@ -1,21 +1,3 @@
-<div id="gsoc-2017"></div>
-## Google Summer of Code 2017
-
-LuaRocks is part of [Google Summer of Code 2017](https://summerofcode.withgoogle.com/)!
-
-If you are an eligible student and wish to apply, you should join the
-[luarocks-developers mailing
-list](https://lists.sourceforge.net/lists/listinfo/luarocks-developers) and
-say hi at our [Gitter group](http://gitter.im/luarocks/luarocks). Check out
-our [ideas list](http://luarocks.github.io/luarocks/gsoc/ideas2017.html) (or
-share your own ideas!). Once you find a project you are interested in, you
-should contact the mentor for that project by email, and fill and send them this
-[questionnaire](http://luarocks.github.io/luarocks/gsoc/apply2017.html). If
-your application looks appropriate, the mentor may ask you to perform some
-small task related to the project to assess your abilities, and discuss with
-you how to best present your proposal. [Proposals accepted from March 20 to
-April 3, 2017](https://summerofcode.withgoogle.com/organizations/5122941307060224/)!
-
 <div id="quick-start"></div>
 ## Quick Start
 

--- a/views/index.moon
+++ b/views/index.moon
@@ -16,8 +16,6 @@ class Index extends require "widgets.page"
   inner_content: =>
     div class: "announce", ->
       div class: "new_tag", "New"
-      text "LuaRocks is taking part in Google Summer of Code 2017! "
-      a href: "https://luarocks.org/#gsoc-2017", "Learn more"
 
     div class: "home_columns", ->
       div class: "column", ->

--- a/views/index.moon
+++ b/views/index.moon
@@ -14,8 +14,6 @@ class Index extends require "widgets.page"
         @inner_content!
 
   inner_content: =>
-    div class: "announce", ->
-      div class: "new_tag", "New"
 
     div class: "home_columns", ->
       div class: "column", ->


### PR DESCRIPTION
Hello there,

This is my very first PR to luarocks-site, just to get my feet wet. 

- Removing the GSOC-2017 announcement section from the index page, as the time to submit proposals has ended a month ago.