### PR TITLE
Stop forcing redirects to HTTP instead of HTTPS

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -99,11 +99,11 @@ http {
 
         # redirect old luarocks releases links
         location /releases {
-          rewrite ^/releases(.*$) http://luarocks.github.io/luarocks/releases$1 redirect;
+          rewrite ^/releases(.*$) https://luarocks.github.io/luarocks/releases$1 redirect;
         }
 
         location /doc/history.pdf {
-          rewrite . http://hisham.hm/papers/muhammad_2013_history.pdf redirect;
+          rewrite . https://hisham.hm/papers/muhammad_2013_history.pdf redirect;
         }
     }
 


### PR DESCRIPTION
Both these links work with HTTPS but currently the website forces a needless redirect to the insecure HTTP protocol.

```
=> curl -IL https://luarocks.org/releases/luarocks-2.4.4.tar.gz

HTTP/1.1 302 Moved Temporarily
Server: nginx/1.12.1
Date: Fri, 23 Mar 2018 01:47:08 GMT
Content-Type: text/html
Content-Length: 167
Connection: keep-alive
Location: http://luarocks.github.io/luarocks/releases/luarocks-2.4.4.tar.gz
```
