### PR TITLE
Fix active header tab for global stats

### DIFF
--- a/views/stats.moon
+++ b/views/stats.moon
@@ -9,7 +9,7 @@ class Stats extends require "widgets.page"
   }
 
   header_content: =>
-    widget Header page_name: "this_week"
+    widget Header page_name: "global"
 
   js_init: =>
     data = {


### PR DESCRIPTION
Header used to highlight "Popular this week" tab as active while "Global stats" is open.
