### PR TITLE
Add Lua 5.4 support

### DIFF
--- a/applications/manifest.moon
+++ b/applications/manifest.moon
@@ -47,7 +47,7 @@ serve_manifest = capture_errors_404 =>
 
   assert_valid @params, {
     {"format", optional: true, one_of: {"json", "zip"}}
-    {"version", optional: true, one_of: {"5.1", "5.2", "5.3"}}
+    {"version", optional: true, one_of: {"5.1", "5.2", "5.3", "5.4"}}
   }
 
   @format = @params.format

--- a/cmd/mirror_server_to_disk.moon
+++ b/cmd/mirror_server_to_disk.moon
@@ -63,7 +63,7 @@ download_manifest = (name) ->
         os.execute "mv '#{tmp_fname}' #{fname}"
         print "done"
 
-for m in *{ "manifest", "manifest-5.1", "manifest-5.2", "manifest-5.3"}
+for m in *{ "manifest", "manifest-5.1", "manifest-5.2", "manifest-5.3", "manifest-5.4"}
   download_manifest m
 
 for fname in pairs existing_files

--- a/helpers/mirror.moon
+++ b/helpers/mirror.moon
@@ -76,7 +76,7 @@ update_manifest_on_disk = (server, dest, force=false) ->
           os.execute "mv '#{tmp_fname}' #{fname}"
           print "done"
 
-  for m in *{ "manifest", "manifest-5.1", "manifest-5.2", "manifest-5.3"}
+  for m in *{ "manifest", "manifest-5.1", "manifest-5.2", "manifest-5.3", "manifest-5.4"}
     download_manifest m
 
   for fname in pairs existing_files

--- a/spec/manifest_spec.moon
+++ b/spec/manifest_spec.moon
@@ -75,7 +75,7 @@ describe "moonrocks", ->
   should_load "/dev/manifest.wow", 404
   should_load "/dev/manifest-5.2.wow", 404
 
-  for v in *{"", "-5.1", "-5.2", "-5.3"}
+  for v in *{"", "-5.1", "-5.2", "-5.3", "-5.4"}
     should_load_manifest "/manifest#{v}", is_empty_manifest
     should_load_manifest "/dev/manifest#{v}", is_empty_manifest
 


### PR DESCRIPTION
Lua 5.4 rc1 hit recently, which means that Lua 5.4 is around the corner. We should be ready to support it. :)

I did this PR by grepping for `"5.3"` and did not set up a full test environment. Please double-check that these changes are correct and sufficient!