### PR TITLE
Add OpenSearch descriptor

### DIFF
--- a/static/opensearch.xml
+++ b/static/opensearch.xml
@@ -1,0 +1,9 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+    <ShortName>LuaRocks</ShortName>
+    <Description>Search LuaRocks</Description>
+    <InputEncoding>UTF-8</InputEncoding>
+    <Image width="16" height="16" type="image/x-icon">https://luarocks.org/favicon.ico</Image>
+    <Url type="text/html" method="get" template="https://luarocks.org/search?q={searchTerms}"/>
+    <moz:SearchForm>https://luarocks.org/</moz:SearchForm>
+</OpenSearchDescription>

--- a/views/layout.moon
+++ b/views/layout.moon
@@ -21,6 +21,7 @@ class Layout extends Widget
 
         link href: "https://fonts.googleapis.com/css?family=Open+Sans:400italic,400,700", rel: "stylesheet", type: "text/css"
         link href: "/static/icons/style.css", rel: "stylesheet", type: "text/css"
+        link href: "/static/opensearch.xml",  rel: "search", type: "application/opensearchdescription+xml", title: "LuaRocks"
 
         if @page_description
           meta name: "description", content: @page_description


### PR DESCRIPTION
This adds an OpenSearch[1] descriptor to the site.

[1]: https://developer.mozilla.org/en-US/docs/Web/OpenSearch