### PR TITLE
check request failure when mirroring

### DIFF
--- a/helpers/mirror.moon
+++ b/helpers/mirror.moon
@@ -65,13 +65,19 @@ update_manifest_on_disk = (server, dest, force=false) ->
 
           tmp_fname = "#{fname}.tmp"
 
-          http.request {
+          res, status = http.request {
             :url
             sink: ltn12.sink.file io.open tmp_fname, "w"
             headers: {
               "user-agent": "moonrocks_backup"
             }
           }
+
+          if (not res) or (type(status) == "number" and status >= 400)
+            seen_files[fname] = nil
+            os.execute "rm '#{tmp_fname}'"
+            print "failed"
+            continue
 
           os.execute "mv '#{tmp_fname}' #{fname}"
           print "done"


### PR DESCRIPTION
A few entries in the LuaRocks.org mirror contain files whose contents are HTML reporting "504 Gateway Time-out".

This PR adds a check to the `http.request` used by the mirroring operation, to ensure that error results are not stored in the mirror.