### PR TITLE
Support serving non-root manifest

### DIFF
--- a/applications/manifest.moon
+++ b/applications/manifest.moon
@@ -107,6 +107,10 @@ class MoonRocksManifest extends lapis.Application
   [sub_manifest: "/m/:manifest/manifest(-:a.:b)(.:format)"]: zipable is_stable serve_manifest
   [sub_manifest_dev: "/m/:manifest/dev/manifest(-:a.:b)(.:format)"]: zipable is_dev serve_manifest
 
+  -- this is done so that file requests from LuaRocks succeed.
+  [sub_manifest_redirect: "/m/:manifest/*"]: => redirect_to: "/#{@params.splat}"
+  [sub_manifest_redirect: "/m/:manifest/dev/*"]: => redirect_to: "/dev/#{@params.splat}"
+
 
   "/dev": => redirect_to: @url_for "root_manifest_dev"
   "/manifests/:user": => redirect_to: @url_for("user_manifest", user: @params.user)

--- a/applications/manifest.moon
+++ b/applications/manifest.moon
@@ -56,6 +56,8 @@ serve_manifest = capture_errors_404 =>
   -- find what we are fetching modules from
   thing = if @params.user
     assert_error Users\find(slug: @params.user), "invalid user"
+  elseif @params.manifest
+    Manifests\find(name: @params.manifest)
   else
     Manifests\root!
 
@@ -102,6 +104,9 @@ class MoonRocksManifest extends lapis.Application
   [root_manifest: "/manifest(-:a.:b)(.:format)"]: zipable is_stable serve_manifest
   [root_manifest_dev: "/dev/manifest(-:a.:b)(.:format)"]: zipable is_dev serve_manifest
   [user_manifest: "/manifests/:user/manifest(-:a.:b)(.:format)"]: zipable serve_manifest
+  [sub_manifest: "/m/:manifest/manifest(-:a.:b)(.:format)"]: zipable is_stable serve_manifest
+  [sub_manifest_dev: "/m/:manifest/dev/manifest(-:a.:b)(.:format)"]: zipable is_dev serve_manifest
+
 
   "/dev": => redirect_to: @url_for "root_manifest_dev"
   "/manifests/:user": => redirect_to: @url_for("user_manifest", user: @params.user)


### PR DESCRIPTION
This PR adds support for pulling non-root manifest files from `/m/:manifest/manifest`.

Fixes #59. Also fixes #141.

I should add that I'm very inexperienced in using Lapis and web dev in general, so I would like confirmation that I'm not breaking the API, creating a bad performance path, adding code in the wrong file, etc.

I'm afraid this could complicate mirrors or other things because all invalid non-root manifest URLs, even if said manifest is fake, redirect to `/*`. If this causes difficulties, I'm happy to change/remove it.