### PR TITLE
Fix outdated documentation links in LuaRocks sitefix outdated documentation link in LuaRocks site

### DIFF
--- a/views/layout.moon
+++ b/views/layout.moon
@@ -119,9 +119,9 @@ class Layout extends Widget
         a href: @url_for("notifications"), title: "notifications", class: "unread_notifications",
           @current_user\get_unseen_notifications_count!
 
-      a href: "https://github.com/luarocks/luarocks/wiki/Download", "Install"
+      a href: "https://github.com/luarocks/luarocks/blob/main/docs/download.md", "Install"
       text " "
-      a href: "https://github.com/luarocks/luarocks/wiki/Documentation", "Docs"
+      a href: "https://github.com/luarocks/luarocks/blob/main/docs/index.md", "Docs"
       text " "
 
       if @current_user


### PR DESCRIPTION
 Description:

This PR updates broken documentation links on the LuaRocks site:

    Installation instructions for Windows
        Old link: https://github.com/luarocks/luarocks/wiki/Installation-instructions-for-Windows
        New link: https://github.com/luarocks/luarocks/blob/main/docs/installation_instructions_for_windows.md

    General documentation page
        Old link: https://github.com/luarocks/luarocks/wiki/Documentation
        New link: https://github.com/luarocks/luarocks/blob/main/docs/index.md

The previous links pointed to the deprecated wiki, while the new ones correctly reference the docs/ folder in the main repo.

Let me know if any further adjustments are needed.