### PR TITLE
Wrap manifest dependencies in functions to bypass luajit "main function has more than 65536 constants" error

### DIFF
--- a/ext/luarocks/persist.lua
+++ b/ext/luarocks/persist.lua
@@ -71,9 +71,9 @@ local write_table
 -- @param level number: the indentation level
 -- @param sub_order table: optional prioritization table
 -- @see write_table
-local function write_value(out, v, level, sub_order)
+local function write_value(out, v, level, sub_order, lua_version)
    if type(v) == "table" then
-      write_table(out, v, level + 1, sub_order)
+      write_table(out, v, level + 1, sub_order, lua_version)
    elseif type(v) == "string" then
       if v:match("\n") then
          local open, close = "[[", "]]"
@@ -100,8 +100,9 @@ end
 -- @param tbl table: the table to be written.
 -- @param level number: the indentation level
 -- @param field_order table: optional prioritization table
-write_table = function(out, tbl, level, field_order)
-   if level == 2 then
+write_table = function(out, tbl, level, field_order, lua_version)
+   -- Fix for "main function has more than 65536 constants" in LuaJIT
+  if lua_version == "5.1" and level == 2 then
      out:write("(function () return {")
    else
      out:write("{")
@@ -127,7 +128,7 @@ write_table = function(out, tbl, level, field_order)
          sep = ", "
       elseif type(k) == "table" then
          out:write("[")
-         write_table(out, k, level + 1)
+         write_table(out, k, level + 1, nil, lua_version)
          out:write("] = ")
       else
          if k:match("^[a-zA-Z_][a-zA-Z0-9_]*$") and not lua_keywords_set[k:lower()] then
@@ -136,13 +137,14 @@ write_table = function(out, tbl, level, field_order)
             out:write("['"..k:gsub("'", "\\'").."'] = ") 
          end
       end
-      write_value(out, v, level, sub_order)
+      write_value(out, v, level, sub_order, lua_version)
    end
    if sep ~= "\n" then
       out:write("\n")
       for n = 1,level-1 do out:write(indentation) end
    end
-   if level == 2 then
+   -- Fix for "main function has more than 65536 constants" in LuaJIT
+   if lua_version == "5.1" and level == 2 then
      out:write("} end)()")
    else
      out:write("}")
@@ -154,7 +156,7 @@ end
 -- @param tbl table: the table to be written.
 -- @param field_order table: optional prioritization table
 -- @return userdata The file object originally passed in as the `out` parameter.
-local function write_table(out, tbl, field_order)
+local function write_table(out, tbl, field_order, lua_version)
    for k, v, sub_order in util.sortedpairs(tbl, field_order) do
 
       if not k:match("^[a-zA-Z_][a-zA-Z0-9_]*$") or lua_keywords_set[k:lower()] then
@@ -162,7 +164,7 @@ local function write_table(out, tbl, field_order)
       end
 
       out:write(k.." = ")
-      write_value(out, v, 0, sub_order)
+      write_value(out, v, 0, sub_order, lua_version)
       out:write("\n")
    end
    return out
@@ -175,10 +177,10 @@ end
 -- @param tbl table: the table containing the data to be written
 -- @param field_order table: an optional array indicating the order of top-level fields.
 -- @return string
-function save_from_table_to_string(tbl, field_order)
+function save_from_table_to_string(tbl, field_order, lua_version)
    local out = {buffer = {}}
    function out:write(data) table.insert(self.buffer, data) end
-   write_table(out, tbl, field_order)
+   write_table(out, tbl, field_order, lua_version)
    return table.concat(out.buffer)
 end
 

--- a/ext/luarocks/persist.lua
+++ b/ext/luarocks/persist.lua
@@ -101,7 +101,11 @@ end
 -- @param level number: the indentation level
 -- @param field_order table: optional prioritization table
 write_table = function(out, tbl, level, field_order)
-   out:write("{")
+   if level == 2 then
+     out:write("(function () return {")
+   else
+     out:write("{")
+   end
    local sep = "\n"
    local indentation = "   "
    local indent = true
@@ -138,7 +142,11 @@ write_table = function(out, tbl, level, field_order)
       out:write("\n")
       for n = 1,level-1 do out:write(indentation) end
    end
-   out:write("}")
+   if level == 2 then
+     out:write("} end)()")
+   else
+     out:write("}")
+   end
 end
 
 --- Writes a table to an io-like object.

--- a/helpers/manifests.moon
+++ b/helpers/manifests.moon
@@ -84,7 +84,7 @@ build_manifest = (modules, filter_version=nil, development=nil) ->
 serve_lua_table = (tab) =>
   @res.headers["Content-type"] = "text/x-lua"
 
-  layout: false, persist.save_from_table_to_string tab
+  layout: false, persist.save_from_table_to_string tab, nil, @version
 
 
 { :build_manifest, :preload_modules, :serve_lua_table }

--- a/spec/helpers_spec.moon
+++ b/spec/helpers_spec.moon
@@ -1,12 +1,11 @@
-
-
 describe "helpers.manifests", ->
   import build_manifest, serve_lua_table from require "helpers.manifests"
 
   local req_stub
+  local req_stub2
 
   before_each ->
-    req_stub = { res: { headers: {} } }
+    req_stub = { res: { headers: {}}, version: "5.2"  }
 
   it "serializes empty table", ->
     assert.same {
@@ -57,6 +56,67 @@ thing = {
 ]]
     }, {
       serve_lua_table req_stub, {
+        thing: {
+          "function": {
+            "do": true
+          }
+          "end": 55
+        }
+      }
+    }
+
+  before_each ->
+    req_stub2 = { res: { headers: {}}, version: "5.1"  }
+
+  it "serializes empty table 5.1", ->
+    assert.same {
+      { layout: false }
+      ''
+    }, {
+      serve_lua_table req_stub2, {}
+    }
+
+
+  it "serializes simple table 5.1", ->
+    assert.same {
+      { layout: false }
+      [[
+hello = {
+   world = (function () return {
+      "a", "b", "c"
+   } end)()
+}
+]]
+    }, {
+      serve_lua_table req_stub2, {
+        hello: {
+          world: {"a", "b", "c"}
+        }
+      }
+    }
+
+  it "fails to serialize with invalid top level key 5.1", ->
+    assert.has_error(
+      ->
+        serve_lua_table req_stub2, {
+          "function": { 1 }
+        }
+      "Invalid top level key: function"
+    )
+
+  it "serializes table with lua keywords 5.1", ->
+    assert.same {
+      { layout: false }
+      [[
+thing = {
+   ['end'] = 55,
+   ['function'] = (function () return {
+      ['do'] = true
+   } end)()
+}
+]]
+    }, {
+      serve_lua_table req_stub2, {
         thing: {
           "function": {
             "do": true


### PR DESCRIPTION
This change wraps each dependency table in a function that returns the table to avoid the luajit limit of 65536 constants in a function.

Here is an example manifest after the change:
```
commands = {}
modules = {}
repository = {
   ['kong-lua-resty-kafka'] = (function () return {
      ['0.21-0'] = {
         {
            arch = "rockspec"
         }
      }
   } end)()
}
```

Fixes: https://github.com/luarocks/luarocks/issues/1797