### PR TITLE
serve zipped json manifests

### DIFF
--- a/applications/manifest.moon
+++ b/applications/manifest.moon
@@ -34,13 +34,15 @@ zipable = (fn) ->
   =>
     @write fn @
 
-    return unless @format == "zip"
+    return unless (@format == "zip" or @format == "json.zip")
     return unless (@options.status or 200) == 200
     return unless @req.cmd_mth == "GET"
 
     fname = "manifest"
     if @version
       fname ..= "-#{@version}"
+    if @format == "json.zip"
+      fname ..= ".json"
 
     @options.content_type = "application/zip"
     @res.content = zipped_file fname, table.concat @buffer
@@ -52,7 +54,7 @@ serve_manifest = capture_errors_404 =>
     @params.version = "#{@params.a}.#{@params.b}"
 
   params = assert_valid @params, types.params_shape {
-    {"format", types.nil + types.one_of {"json", "zip"}}
+    {"format", types.nil + types.one_of {"json", "zip", "json.zip"}}
     {"version", types.nil + types.one_of {"5.1", "5.2", "5.3", "5.4", "5.5"}}
 
     {"user", types.nil + types.limited_text(256) / slugify }
@@ -94,7 +96,7 @@ serve_manifest = capture_errors_404 =>
   modules = get_all_pages pager
   manifest = build_manifest modules, @version, @development
 
-  if @format == "json"
+  if @format == "json" or @format == "json.zip"
     json: manifest
   else
     serve_lua_table @, manifest


### PR DESCRIPTION
This is my attempt to kickstart #225.

Some caveats:

- I've never worked with moonscript, lapis or OpenResty, but based on my analysis of the existing code in `applications/manifest.moon` and `helpers/manifests.moon`, this may be enough to add the capability to serve a zipped json manifest?
- I don't know how to generate Lua code from the moonscript code.
- I have been unable to set up a dev environment using the guide in the readme.

The `tup` command fails with:

```console
  11) [0.072s] views: moonc about.moon                                                                                      
  10) [0.062s] moonc revision.moon                                                                                          
   9) [0.057s] moonc models.moon                                                                                            
   8) [0.049s] moonc lint_config.moon                                                                                       
   7) [0.052s] moonc config.moon                                                                                            
   6) [0.068s] moonc migrations.moon                                                                                        
   5) [0.059s] moonc app.moon                                                                                               
*   4) compile_js views/edit_module.lua > views/edit_module.js                                                              
/bin/sh: line 1: lapis-eswidget: command not found
 *** tup messages ***
 *** Command ID=790 failed with return value 127
*   3) compile_js views/index.lua > views/index.js                                                                          
/bin/sh: line 1: lapis-eswidget: command not found
 *** tup messages ***
 *** Command ID=792 failed with return value 127
*   2) compile_js views/stats.lua > views/stats.js                                                                          
/bin/sh: line 1: lapis-eswidget: command not found
 *** tup messages ***
 *** Command ID=794 failed with return value 127
 [                                          ETA~=<1s Remaining=2   Active=0                                           ]  98%
 *** tup: 3 jobs failed.
```

(this is after setting up the luarocks path).

- This would probably need some tests, but without being able to set up a dev environment,
  I don't want to risk wasting too much effort.

Perhaps someone who is more familiar with this codebase is willing to pick this up if it's going in the right direction?
